### PR TITLE
Amann/feature/no more hacky time buffer thing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,45 @@
+version: 2.1
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test
+
+cache: &cache v0-{{ checksum "setup.py" }}
+
+jobs:
+  test:
+    docker:
+      - image: python:3.9.5-buster
+    working_directory: /code/
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - *cache
+
+      - run:
+          name: Install tap-circle-ci
+          command: |
+            python -m venv venv/tap-circle-ci
+            source venv/tap-circle-ci/bin/activate
+            pip install -e .[tests]
+            deactivate
+
+      - save_cache:
+          key: *cache
+          paths:
+            - "./venv"
+            - "/usr/local/bin"
+            - "/usr/local/lib/python3.9/site-packages"
+
+      - run:
+          name: Run Tests
+          command: |
+            source venv/tap-circle-ci/bin/activate
+            pytest --verbose
+
+      - store_artifacts:
+          path: target/test-results
+          destination: raw-test-output

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.egg
 __pycache__/
 
+venv/
 sample_config.json
 catalog.json

--- a/README.md
+++ b/README.md
@@ -103,6 +103,29 @@ This tap:
    It is our intention that this singer tap gets used with a singer target, which will load the output into a database.
    More information on singer targets [here](https://github.com/singer-io/getting-started/blob/master/docs/RUNNING_AND_DEVELOPING.md#running-a-singer-tap-with-a-singer-target).
 
+7. To rerun using the last output `STATE` record:
+
+   In your output records, you will see something like:
+
+   ```json
+   {
+     "type": "STATE",
+     "value": {
+       "bookmarks": {
+         "gh/sisudata/tap-circle-ci": {
+           "pipelines": { "since": "2021-05-28T22:02:27.620127Z" }
+         }
+       }
+     }
+   }
+   ```
+
+   Select the `value` key, store it to a JSON file, and run:
+
+   ```bash
+   tap-circle-ci --config config.json --catalog catalog.json --state state.json
+   ```
+
 ## Configuration
 
 Detailed configuration information for the `--config` key.

--- a/README.md
+++ b/README.md
@@ -14,88 +14,95 @@ This tap:
 - Outputs the schema for each resource
 - Incrementally pulls data based on the input state
 
-
 ## Quick start
 
 1. Install
 
-    ```bash
-    git clone git@github.com:sisudata/tap-circle-ci.git && cd tap-circle-ci && pip install -e .
-    ```
+   ```bash
+   git clone git@github.com:sisudata/tap-circle-ci.git && cd tap-circle-ci && pip install -e .
+   ```
 
 2. Create a Circle CI access token
 
-    Login to your Circle CI account, go to the
-    [Personal API Tokens](https://circleci.com/account/api)
-    page, and generate a new token. Copy the token and save it somewhere safe.
+   Login to your Circle CI account, go to the
+   [Personal API Tokens](https://circleci.com/account/api)
+   page, and generate a new token. Copy the token and save it somewhere safe.
 
 3. Create the config file
 
-    Create a JSON file containing the token you just created as well as the project slug to the project you want to extract data from. Retrieve the project slug
-    from the url for a workflow - it should be the VCS your project uses (`gh` for Github or `bb` for Bitbucket), followed by the owner or organization, followed by the repository name
-    ex. `gh/singer-io/singer-python`. You can enter multiple project slugs separated by spaces to pull data from multiple projects.
+   Create a JSON file containing the token you just created as well as the project slug to the project you want to extract data from. Retrieve the project slug
+   from the url for a workflow - it should be the VCS your project uses (`gh` for Github or `bb` for Bitbucket), followed by the owner or organization, followed by the repository name
+   ex. `gh/singer-io/singer-python`. You can enter multiple project slugs separated by spaces to pull data from multiple projects.
 
-    ```json
-    {
-      "token": "your-access-token",
-      "project_slugs": "gh/singer-io/singer-python gh/singer-io/getting-started"
-    }
-    ```
+   ```json
+   {
+     "token": "your-access-token",
+     "project_slugs": "gh/singer-io/singer-python gh/singer-io/getting-started"
+   }
+   ```
+
 4. Run the tap in discovery mode to get catalog.json file
 
-    ```bash
-    tap-circle-ci --config config.json --discover > catalog.json
-    ```
+   ```bash
+   tap-circle-ci --config config.json --discover > catalog.json
+   ```
+
 5. In the catalog.json file, select the streams to sync
 
-    Each stream in the properties.json file has a "metadata" entry.  To select a stream to sync, add
-    `{"breadcrumb": [], "metadata": {"selected": true}}` to that stream's "metadata" entry.  
-    For example, to sync the pipelines stream:
-    ```
-    ...
-        "type": [
-          "null",
-          "object"
-        ],
-        "additionalProperties": false
-      },
-      "stream": "pipelines",
-      "metadata": [{"breadcrumb": [], "metadata": {"selected": true}}]
-    },
-    ...
-    ```
-    Another way to select a stream to sync is to add `"selected": true` into that stream's schema:
+   Each stream in the properties.json file has a "metadata" entry. To select a stream to sync, add
+   `{"breadcrumb": [], "metadata": {"selected": true}}` to that stream's "metadata" entry.  
+   For example, to sync the pipelines stream:
 
-    ```
-    ...
-    "tap_stream_id": "workflows",
-    "key_properties": [],
-    "schema": {
-      "selected": true,
-      "properties": {
-        "_pipeline_id": {
-          "type": [
-            "null",
-            "string"
-          ]
-    ...
-    ```
-    Either way is acceptable, but the first way is preferred.
+   ```
+   ...
+       "type": [
+         "null",
+         "object"
+       ],
+       "additionalProperties": false
+     },
+     "stream": "pipelines",
+     "metadata": [{"breadcrumb": [], "metadata": {"selected": true}}]
+   },
+   ...
+   ```
+
+   Another way to select a stream to sync is to add `"selected": true` into that stream's schema:
+
+   ```
+   ...
+   "tap_stream_id": "workflows",
+   "key_properties": [],
+   "schema": {
+     "selected": true,
+     "properties": {
+       "_pipeline_id": {
+         "type": [
+           "null",
+           "string"
+         ]
+   ...
+   ```
+
+   Either way is acceptable, but the first way is preferred.
 
 6. Run the application (will print records and other messages to the console)
 
-    `tap-circle-ci` can be run with:
+   `tap-circle-ci` can be run with:
 
-    ```bash
-    tap-circle-ci --config config.json --catalog catalog.json
-    ```
+   ```bash
+   tap-circle-ci --config config.json --catalog catalog.json
+   ```
 
-    To save output to a file:
-    ```bash
-    tap-circle-ci --config config.json --catalog catalog.json > output.txt
-    ```
-    It is our intention that this singer tap gets used with a singer target, which will load the output into a database.
-    More information on singer targets [here](https://github.com/singer-io/getting-started/blob/master/docs/RUNNING_AND_DEVELOPING.md#running-a-singer-tap-with-a-singer-target).
+   To save output to a file:
+
+   ```bash
+   tap-circle-ci --config config.json --catalog catalog.json > output.txt
+   ```
+
+   It is our intention that this singer tap gets used with a singer target, which will load the output into a database.
+   More information on singer targets [here](https://github.com/singer-io/getting-started/blob/master/docs/RUNNING_AND_DEVELOPING.md#running-a-singer-tap-with-a-singer-target).
+
 ---
 
 Copyright &copy; 2020 Sisu Data

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This tap:
    [Personal API Tokens](https://circleci.com/account/api)
    page, and generate a new token. Copy the token and save it somewhere safe.
 
-3. Create the config file
+3. Create the config file (see below)
 
    Create a JSON file containing the token you just created as well as the project slug to the project you want to extract data from. Retrieve the project slug
    from the url for a workflow - it should be the VCS your project uses (`gh` for Github or `bb` for Bitbucket), followed by the owner or organization, followed by the repository name
@@ -102,6 +102,16 @@ This tap:
 
    It is our intention that this singer tap gets used with a singer target, which will load the output into a database.
    More information on singer targets [here](https://github.com/singer-io/getting-started/blob/master/docs/RUNNING_AND_DEVELOPING.md#running-a-singer-tap-with-a-singer-target).
+
+## Configuration
+
+Detailed configuration information for the `--config` key.
+
+| key                | type      | default | description                                                                                     |
+| ------------------ | --------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `token`            | `string`  | `N/A`   | [Personal API Token](https://circleci.com/account/api)                                          |
+| `project_slugs`    | `string`  | `N/A`   | Space ` ` delimited string of CCI project slugs                                                 |
+| `time_buffer_mins` | `integer` | 7 days  | A buffer to offset when we start syncing `pipelines` to prevent syncing in progress `pipelines` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This tap:
 
 - Pulls raw data from [Circle CI](https://circleci.com/)
 - Extracts the following resources:
-  - [Pipelines](https://circleci.com/docs/api/v2/#get-all-pipelines)
+  - [Pipelines](hhttps://circleci.com/docs/api/v2/#operation/listPipelines)
   - [Workflows](https://circleci.com/docs/api/v2/#operation/listWorkflowsByPipelineId)
   - [Jobs](https://circleci.com/docs/api/v2/#operation/listWorkflowJobs)
   - [Steps](https://circleci.com/docs/api/#single-job)

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This tap:
 - Pulls raw data from [Circle CI](https://circleci.com/)
 - Extracts the following resources:
   - [Pipelines](https://circleci.com/docs/api/v2/#get-all-pipelines)
-  - [Workflows](https://circleci.com/docs/api/v2/#get-a-pipeline-39-s-workflows)
-  - [Jobs](https://circleci.com/docs/api/v2/#get-a-workflow-39-s-jobs)
+  - [Workflows](https://circleci.com/docs/api/v2/#operation/listWorkflowsByPipelineId)
+  - [Jobs](https://circleci.com/docs/api/v2/#operation/listWorkflowJobs)
 - Outputs the schema for each resource
 - Incrementally pulls data based on the input state
 

--- a/README.md
+++ b/README.md
@@ -131,11 +131,10 @@ This tap:
 
 Detailed configuration information for the `--config` key.
 
-| key                | type      | default | description                                                                                     |
-| ------------------ | --------- | ------- | ----------------------------------------------------------------------------------------------- |
-| `token`            | `string`  | `N/A`   | [Personal API Token](https://circleci.com/account/api)                                          |
-| `project_slugs`    | `string`  | `N/A`   | Space ` ` delimited string of CCI project slugs                                                 |
-| `time_buffer_mins` | `integer` | 7 days  | A buffer to offset when we start syncing `pipelines` to prevent syncing in progress `pipelines` |
+| key             | type     | default | description                                            |
+| --------------- | -------- | ------- | ------------------------------------------------------ |
+| `token`         | `string` | `N/A`   | [Personal API Token](https://circleci.com/account/api) |
+| `project_slugs` | `string` | `N/A`   | Space ` ` delimited string of CCI project slugs        |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This tap:
   - [Pipelines](https://circleci.com/docs/api/v2/#get-all-pipelines)
   - [Workflows](https://circleci.com/docs/api/v2/#operation/listWorkflowsByPipelineId)
   - [Jobs](https://circleci.com/docs/api/v2/#operation/listWorkflowJobs)
+  - [Steps](https://circleci.com/docs/api/#single-job)
 - Outputs the schema for each resource
 - Incrementally pulls data based on the input state
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  tap:
+    image: python:3.9.5-buster
+    entrypoint: /code/docker-entrypoint.sh
+    working_dir: /code
+    environment:
+      DEPLOYMENT: "${DEPLOYMENT}"
+    volumes:
+      - .:/code

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+python -m venv venv/tap-circle-ci
+source /code/venv/target-postgres/bin/activate
+
+pip install -e .[tests]
+
+echo "source /code/venv/tap-circle-ci/bin/activate" >> ~/.bashrc
+echo -e "\n\nINFO: Dev environment ready."
+
+tail -f /dev/null

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+filterwarnings =
+    error
+    ignore::UserWarning
+    ignore:.*Using or importing the ABCs from:DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,13 @@ setup(
     py_modules=["tap_circle_ci"],
     install_requires=[
         "singer-python>=5.0.12",
-        "requests",
-        "pytest",
-        "mock"
+        "requests"
     ],
+    extras_require={
+        'tests': [
+            "mock",
+            "pytest"
+        ]},
     entry_points="""
     [console_scripts]
     tap-circle-ci=tap_circle_ci:main

--- a/tap_circle_ci/client.py
+++ b/tap_circle_ci/client.py
@@ -5,8 +5,11 @@ import singer.metrics as metrics
 
 _session = Session()
 # wrapper to make mocking easier
+
+
 def get_session():
     return _session
+
 
 logger = singer.get_logger()
 
@@ -28,11 +31,12 @@ def add_next_page_to_url(url: str, next_page_token: str) -> str:
 class AuthException(Exception):
     pass
 
+
 class NotFoundException(Exception):
     pass
 
 
-def get(source: str, url: str, headers: dict={}):
+def get(source: str, url: str, headers: dict = {}):
     """
     Get a single page from the provided url
     """
@@ -50,7 +54,7 @@ def get(source: str, url: str, headers: dict={}):
         return resp
 
 
-def get_all_pages(source: str, url: str, headers: dict={}):
+def get_all_pages(source: str, url: str, headers: dict = {}):
     temp_url = str(url)
     while True:
         r = get(source, temp_url, headers)
@@ -64,7 +68,7 @@ def get_all_pages(source: str, url: str, headers: dict={}):
             break
 
 
-def get_all_items(source: str, url: str, headers: dict={}):
+def get_all_items(source: str, url: str, headers: dict = {}):
     """
     Each page contains a bunch of items, so this function extracts the items one by one
     """

--- a/tap_circle_ci/client.py
+++ b/tap_circle_ci/client.py
@@ -11,7 +11,7 @@ def get_session():
     return _session
 
 
-logger = singer.get_logger()
+LOGGER = singer.get_logger()
 
 
 def add_authorization_header(token: str) -> None:
@@ -73,5 +73,5 @@ def get_all_items(source: str, url: str, headers: dict = {}):
     Each page contains a bunch of items, so this function extracts the items one by one
     """
     for page in get_all_pages(source, url, headers):
-        for item in page["items"]:
+        for item in page.get("items", [page]):
             yield item

--- a/tap_circle_ci/schemas/jobs.json
+++ b/tap_circle_ci/schemas/jobs.json
@@ -6,16 +6,16 @@
   "additionalProperties": false,
   "properties": {
     "_pipeline_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": "string"
     },
     "_workflow_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": "string"
+    },
+    "pipeline_id": {
+      "type": "string"
+    },
+    "workflow_id": {
+      "type": "string"
     },
     "dependencies": {
       "type": [
@@ -36,10 +36,7 @@
       ]
     },
     "id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": "string"
     },
     "canceled_by": {
       "type": [
@@ -91,5 +88,6 @@
       ],
       "format": "date-time"
     }
-  }
+  },
+  "required": ["pipeline_id", "workflow_id", "id"]
 }

--- a/tap_circle_ci/schemas/pipelines.json
+++ b/tap_circle_ci/schemas/pipelines.json
@@ -1,15 +1,9 @@
 {
-  "type": [
-    "null",
-    "object"
-  ],
+  "type": "object",
   "additionalProperties": false,
   "properties": {
     "id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": "string"
     },
     "project_slug": {
       "type": [
@@ -152,5 +146,6 @@
         }
       }
     }
-  }
+  },
+  "required": ["id"]
 }

--- a/tap_circle_ci/schemas/steps.json
+++ b/tap_circle_ci/schemas/steps.json
@@ -1,0 +1,71 @@
+{
+  "type": ["null", "object"],
+  "additionalProperties": false,
+  "properties": {
+    "_pipeline_id": {
+      "type": ["null", "string"]
+    },
+    "_workflow_id": {
+      "type": ["null", "string"]
+    },
+    "_job_id": {
+      "type": ["null", "string"]
+    },
+    "_index": {
+      "type": ["null", "integer"]
+    },
+    "name": {
+      "type": ["null", "string"]
+    },
+    "actions": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "object"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "bash_command": {
+            "type": ["null", "string"]
+          },
+          "type": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "string"]
+          },
+          "exit_code": {
+            "type": ["null", "integer"]
+          },
+          "failed": {
+            "type": ["null", "boolean"]
+          },
+          "infrastructure_fail": {
+            "type": ["null", "boolean"]
+          },
+          "timedout": {
+            "type": ["null", "boolean"]
+          },
+          "parallel": {
+            "type": ["null", "boolean"]
+          },
+          "step": {
+            "type": ["null", "integer"]
+          },
+          "index": {
+            "type": ["null", "integer"]
+          },
+          "start_time": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "end_time": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tap_circle_ci/schemas/steps.json
+++ b/tap_circle_ci/schemas/steps.json
@@ -3,13 +3,22 @@
   "additionalProperties": false,
   "properties": {
     "_pipeline_id": {
-      "type": ["null", "string"]
+      "type": "string"
     },
     "_workflow_id": {
-      "type": ["null", "string"]
+      "type": "string"
     },
     "_job_id": {
-      "type": ["null", "string"]
+      "type": "string"
+    },
+    "pipeline_id": {
+      "type": "string"
+    },
+    "workflow_id": {
+      "type": "string"
+    },
+    "job_id": {
+      "type": "string"
     },
     "_index": {
       "type": ["null", "integer"]
@@ -67,5 +76,6 @@
         }
       }
     }
-  }
+  },
+  "required": ["pipeline_id", "workflow_id", "job_id", "_index"]
 }

--- a/tap_circle_ci/schemas/workflows.json
+++ b/tap_circle_ci/schemas/workflows.json
@@ -37,10 +37,7 @@
       ]
     },
     "id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": "string"
     },
     "created_at": {
       "type": [
@@ -50,10 +47,8 @@
       "format": "date-time"
     },
     "pipeline_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": "string"
     }
-  }
+  },
+  "required": ["pipeline_id", "id"]
 }

--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -144,7 +144,12 @@ def get_all_jobs_for_workflow(
     for job in get_all_items('jobs', job_url):
 
         # add in workflow_id and pipeline_id
-        job.update({'_pipeline_id': pipeline_id, '_workflow_id': workflow_id})
+        job.update({
+            '_pipeline_id': pipeline_id,
+            '_workflow_id': workflow_id,
+            'pipeline_id': pipeline_id,
+            'workflow_id': workflow_id,
+        })
 
         # Transform and write
         with singer.Transformer() as transformer:
@@ -189,8 +194,15 @@ def get_all_steps_for_job(
         for idx, step in enumerate(build["steps"]):
 
             # add in workflow_id, pipeline_id and job_id
-            step.update({'_pipeline_id': pipeline_id, '_workflow_id': workflow_id,
-                         '_job_id': workflow_id, '_index': idx})
+            step.update({
+                '_pipeline_id': pipeline_id,
+                '_workflow_id': workflow_id,
+                '_job_id': workflow_id,
+                'pipeline_id': pipeline_id,
+                'workflow_id': workflow_id,
+                'job_id': workflow_id,
+                '_index': idx
+            })
 
             # Transform and write
             with singer.Transformer() as transformer:

--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -1,4 +1,3 @@
-import datetime
 from typing import List, Optional
 
 import singer

--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -10,7 +10,7 @@ from tap_circle_ci.client import get_all_items
 LOGGER = singer.get_logger()
 
 # We leave a week offset for currently running pipelines
-TIME_BUFFER_FOR_RUNNING_PIPELINES = datetime.timedelta(minutes=7)
+TIME_BUFFER_FOR_RUNNING_PIPELINES = datetime.timedelta(days=7)
 
 
 def get_bookmark(state: dict, project: str, stream_name: str, bookmark_key: str) -> Optional[str]:

--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -23,7 +23,7 @@ def get_bookmark(state: dict, project: str, stream_name: str, bookmark_key: str)
     return None
 
 
-def get_all_pipelines(schemas: dict, project: str, state: dict, metadata: dict) -> dict:
+def get_all_pipelines(schemas: dict, project: str, state: dict, metadata: dict, options: dict = {}) -> dict:
     """
     https://circleci.com/docs/api/v2/#get-all-pipelines
     """
@@ -40,7 +40,13 @@ def get_all_pipelines(schemas: dict, project: str, state: dict, metadata: dict) 
     job_counter = metrics.record_counter(
         'jobs') if schemas.get('jobs') else None
     extraction_time = singer.utils.now()
-    extraction_time_minus_buffer = extraction_time - TIME_BUFFER_FOR_RUNNING_PIPELINES
+
+    time_buffer = TIME_BUFFER_FOR_RUNNING_PIPELINES
+    if "time_buffer_mins" in options:
+        time_buffer = datetime.timedelta(minutes=options["time_buffer_mins"])
+
+    extraction_time_minus_buffer = extraction_time - time_buffer
+
     for pipeline in get_all_items('pipelines', pipeline_url):
 
         # We leave a buffer before extracting a pipeline as a hack to avoid extracting currently running pipelines

--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -82,7 +82,7 @@ def get_all_workflows_for_pipeline(
         job_counter: Optional[metrics.Counter] = None
     ) -> dict:
     """
-    https://circleci.com/docs/api/v2/#get-a-pipeline-39-s-workflows
+    https://circleci.com/docs/api/v2/#operation/listWorkflowsByPipelineId
     """
     if workflow_counter is None:
         workflow_counter = metrics.record_counter('workflows')
@@ -114,7 +114,7 @@ def get_all_jobs_for_workflow(
         job_counter: Optional[metrics.Counter] = None
     ) -> dict:
     """
-    https://circleci.com/docs/api/v2/#get-a-workflow-39-s-jobs
+    https://circleci.com/docs/api/v2/#operation/listWorkflowJobs
     """
 
     if job_counter is None:

--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -1,3 +1,4 @@
+import sys
 from typing import List, Optional
 
 import singer
@@ -24,6 +25,30 @@ def pipeline_is_completed(workflows):
     return not running_workflows
 
 
+def get_size(obj, seen=None):
+    """
+    Recursively finds size of objects
+    https://gist.githubusercontent.com/bosswissam/a369b7a31d9dcab46b4a034be7d263b2/raw/f99d210019c1fac6bb46d2da81dcdf5ef9932172/pysize.py
+    """
+    size = sys.getsizeof(obj)
+    if seen is None:
+        seen = set()
+    obj_id = id(obj)
+    if obj_id in seen:
+        return 0
+    # Important mark as seen *before* entering recursion to gracefully handle
+    # self-referential objects
+    seen.add(obj_id)
+    if isinstance(obj, dict):
+        size += sum([get_size(v, seen) for v in obj.values()])
+        size += sum([get_size(k, seen) for k in obj.keys()])
+    elif hasattr(obj, '__dict__'):
+        size += get_size(obj.__dict__, seen)
+    elif hasattr(obj, '__iter__') and not isinstance(obj, (str, bytes, bytearray)):
+        size += sum([get_size(i, seen) for i in obj])
+    return size
+
+
 def get_all_pipelines_while_bookmark(project, bookmark_time):
     """
     Return all pipelines, in ascending order of updated_at, which are
@@ -35,6 +60,7 @@ def get_all_pipelines_while_bookmark(project, bookmark_time):
     # Pipelines are ordered updated_at desc, so we reverse the list
     pipelines = []
     for pipeline in get_all_items('pipelines', pipeline_url):
+        LOGGER.info(f"pipeline size: {get_size(pipeline)}")
         pipeline_updated_at = singer.utils.strptime_to_utc(
             pipeline.get('updated_at'))
 
@@ -45,6 +71,8 @@ def get_all_pipelines_while_bookmark(project, bookmark_time):
             break
 
         pipelines.append(pipeline)
+
+    LOGGER.info(f"pipelines size: {get_size(pipelines)}, {len(pipelines)}")
 
     return pipelines[::-1]
 

--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -25,7 +25,7 @@ def get_bookmark(state: dict, project: str, stream_name: str, bookmark_key: str)
 
 def get_all_pipelines(schemas: dict, project: str, state: dict, metadata: dict, options: dict = {}) -> dict:
     """
-    https://circleci.com/docs/api/v2/#get-all-pipelines
+    https://circleci.com/docs/api/v2/#operation/listPipelines
     """
     bookmark = get_bookmark(state, project, "pipelines", "since")
     if bookmark:

--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -99,7 +99,8 @@ def get_all_pipelines(schemas: dict, project: str, state: dict, metadata: dict, 
     for pipeline in get_all_pipelines_while_bookmark(project, bookmark_time):
         # grab all workflows for this pipeline
         workflow_extraction_time = singer.utils.now()
-        workflows = list(get_all_workflows_for_pipeline(pipeline.get("id")))
+        workflows = get_all_workflows_for_pipeline(pipeline.get("id"))
+        LOGGER.info(f"workflows size: {get_size(workflows)}, {len(workflows)}")
 
         # We terminate extracting once we come across currently running pipelines
         if not pipeline_is_completed(workflows):
@@ -148,10 +149,10 @@ def get_all_workflows_for_pipeline(
     """
     https://circleci.com/docs/api/v2/#operation/listWorkflowsByPipelineId
     """
-    workflow_url = f"https://circleci.com/api/v2/pipeline/{pipeline_id}/workflow"
-
-    for workflow in get_all_items('workflows', workflow_url):
-        yield workflow
+    return list(get_all_items(
+        'workflows',
+        f"https://circleci.com/api/v2/pipeline/{pipeline_id}/workflow"
+    ))
 
 
 def emit_all_workflows_for_pipeline(

--- a/tap_circle_ci/tap_circle_ci.py
+++ b/tap_circle_ci/tap_circle_ci.py
@@ -40,9 +40,8 @@ def discover() -> singer.catalog.Catalog:
 
     for schema_name, schema in raw_schemas.items():
 
-        # TODO: populate any metadata and stream's key properties here..
+        # TODO: populate any metadata here..
         stream_metadata = []
-        stream_key_properties = []
 
         # create and add catalog entry
         catalog_entry = {

--- a/tap_circle_ci/tap_circle_ci.py
+++ b/tap_circle_ci/tap_circle_ci.py
@@ -50,7 +50,7 @@ def discover() -> singer.catalog.Catalog:
             'tap_stream_id': schema_name,
             'schema': schema,
             'metadata': [],
-            'key_properties': []
+            'key_properties': schema.get('required', [])
         }
         streams.append(catalog_entry)
 

--- a/tap_circle_ci/tap_circle_ci.py
+++ b/tap_circle_ci/tap_circle_ci.py
@@ -8,17 +8,20 @@ import singer
 from singer import utils, metadata
 
 from tap_circle_ci.streams import (TOP_LEVEL_STREAM_ID_TO_FUNCTION,
-                                                            STREAM_ID_TO_SUB_STREAM_IDS,
-                                                            validate_stream_dependencies)
+                                   STREAM_ID_TO_SUB_STREAM_IDS,
+                                   validate_stream_dependencies)
 from tap_circle_ci.client import add_authorization_header
 
 REQUIRED_CONFIG_KEYS = ["token", "project_slugs"]
 LOGGER = singer.get_logger()
 
+
 def get_abs_path(path: str) -> str:
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
 # Load schemas from schemas folder
+
+
 def load_schemas() -> dict:
     schemas = {}
 
@@ -29,6 +32,7 @@ def load_schemas() -> dict:
             schemas[file_raw] = json.load(file)
 
     return schemas
+
 
 def discover() -> singer.catalog.Catalog:
     raw_schemas = load_schemas()
@@ -45,12 +49,13 @@ def discover() -> singer.catalog.Catalog:
             'stream': schema_name,
             'tap_stream_id': schema_name,
             'schema': schema,
-            'metadata' : [],
+            'metadata': [],
             'key_properties': []
         }
         streams.append(catalog_entry)
 
     return singer.catalog.Catalog.from_dict({'streams': streams})
+
 
 def get_selected_streams(catalog: singer.catalog.Catalog) -> list:
     '''
@@ -76,7 +81,8 @@ def extract_sub_stream_ids(stream_id: str) -> List[str]:
     Get all children, grandchildren, etc.
     """
     if stream_id in STREAM_ID_TO_SUB_STREAM_IDS:
-        next_level_streams = [sub_id for sub_id in STREAM_ID_TO_SUB_STREAM_IDS[stream_id]]
+        next_level_streams = [
+            sub_id for sub_id in STREAM_ID_TO_SUB_STREAM_IDS[stream_id]]
         # Recurse
         lowel_level_streams = []
         for sub_id in next_level_streams:
@@ -117,7 +123,8 @@ def sync_single_project(project: str, state: dict, catalog: singer.catalog.Catal
             stream_schema = stream.schema
             all_metadata = {stream_id: stream.metadata}
             if stream_id in selected_stream_ids:
-                singer.write_schema(stream_id, stream_schema.to_dict(), stream.key_properties)
+                singer.write_schema(
+                    stream_id, stream_schema.to_dict(), stream.key_properties)
 
                 # get sync function and any sub streams
                 sync_func = TOP_LEVEL_STREAM_ID_TO_FUNCTION[stream_id]
@@ -130,8 +137,10 @@ def sync_single_project(project: str, state: dict, catalog: singer.catalog.Catal
                     # get and write selected sub stream schemas
                     for sub_stream_id in sub_stream_ids:
                         if sub_stream_id in selected_stream_ids:
-                            LOGGER.info(f'Syncing substream: {sub_stream_id} (descendent of {stream_id})')
-                            sub_stream = next(s for s in catalog.streams if s.tap_stream_id == sub_stream_id)
+                            LOGGER.info(
+                                f'Syncing substream: {sub_stream_id} (descendent of {stream_id})')
+                            sub_stream = next(
+                                s for s in catalog.streams if s.tap_stream_id == sub_stream_id)
                             stream_schemas[sub_stream_id] = sub_stream.schema
                             all_metadata[sub_stream_id] = sub_stream.metadata
                             singer.write_schema(sub_stream_id, sub_stream.schema.to_dict(),
@@ -157,9 +166,10 @@ def main():
         if args.catalog:
             catalog = args.catalog
         else:
-            catalog =  discover()
+            catalog = discover()
 
         sync(args.config, args.state, catalog)
+
 
 if __name__ == "__main__":
     main()

--- a/tap_circle_ci/tap_circle_ci.py
+++ b/tap_circle_ci/tap_circle_ci.py
@@ -100,10 +100,10 @@ def sync(config: dict, state: dict, catalog: dict) -> None:
     add_authorization_header(config['token'])
     for project in projects:
         LOGGER.info(f'Syncing project {project}')
-        sync_single_project(project, state, catalog)
+        sync_single_project(project, state, catalog, config)
 
 
-def sync_single_project(project: str, state: dict, catalog: singer.catalog.Catalog) -> None:
+def sync_single_project(project: str, state: dict, catalog: singer.catalog.Catalog, options: dict) -> None:
     """
     Sync a single project's streams
     """
@@ -147,7 +147,7 @@ def sync_single_project(project: str, state: dict, catalog: singer.catalog.Catal
                                             sub_stream.key_properties)
 
             # sync stream and it's sub streams
-            state = sync_func(stream_schemas, project, state, all_metadata)
+            state = sync_func(stream_schemas, project, state, all_metadata, options)
             singer.write_state(state)
 
 


### PR DESCRIPTION
# Motivation

The lag buffer is admittedly hacky, and by pre-fetching the `pipelines`, and then pre-fetching the `workflows` we can sidestep that annoying problem.

## Notes

This does increase the memory footprint of this `tap` on the first run as we have to pull _all_ `pipelines` in at the same time. 

For estimating memory footprint of each `pipeline` we can use estimations detailed below. However, simply instrumenting the pipeline code with `sys.getsizeof` we can get some benchmarks. The commit producing these results is included in the history of this pr, and backed out so as to not clutter the `tap` itself:

```
INFO pipeline size: 4017
INFO pipeline size: 3982
INFO pipeline size: 3976
INFO pipeline size: 3996
INFO pipeline size: 3978
INFO pipeline size: 3973
INFO pipeline size: 3992
INFO pipeline size: 3962
INFO pipeline size: 3959
INFO pipeline size: 3971
INFO pipeline size: 3954
INFO pipeline size: 3960
INFO pipeline size: 3951
INFO pipeline size: 3927
INFO pipeline size: 3938
INFO pipeline size: 3833
INFO pipelines size: 44229, 16
...
INFO workflows size: 1584, 1
...
INFO workflows size: 1578, 1
...
INFO workflows size: 1578, 1
...
INFO workflows size: 1578, 1
...
INFO workflows size: 1578, 1
...
INFO workflows size: 1577, 1
...
NFO workflows size: 1578, 1
...
INFO workflows size: 1578, 1
...
```

Max size of a `pipeline`: 4017
Max size of a `workflow`: 1584

Let's say that unlike this repo, a `pipeline` has a worst case size of 4200 bytes. That would mean being able to fit 238 pipelines into a single megabyte. For a lot of folks, it's not unreasonable to assign half a gig to a running process. Even doing something like lambda, you're reasonably taking 512 MB. That'd be ➡️ 238 * 512 = 121,856 `pipelines` able to fit in memory. With other overheads, let's just make this number 100K.

This is ONLY for the initial sync as well. Every-time after, we should be able to stop after only a few pages because of our bookmark.

Finally, let's say that also unlike this repo, a `pipeline` has on average 5 `workflows`, they're 1600 each (which is really including some overhead for the list, but etc.). That's an additional 8 kilobytes (negligible).

### Sources

- https://rushter.com/blog/python-strings-and-memory/
- https://stackoverflow.com/questions/10264874/python-reducing-memory-usage-of-dictionary

## Suggested Musical Pairing

https://soundcloud.com/deathfromabove1979/one-one
